### PR TITLE
add feat/current episode service

### DIFF
--- a/custom_components/trakt_tv/__init__.py
+++ b/custom_components/trakt_tv/__init__.py
@@ -28,6 +28,7 @@ PLATFORMS = ["sensor"]
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the TraktTV component from a yaml (not supported)."""
     update_domain_data(hass, "configuration", CONFIG_SCHEMA(config).get(DOMAIN, {}))
+
     return True
 
 
@@ -69,6 +70,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
+
+    async def handle_get_next_episode(call):
+        """Handle the service call."""
+        id = call.data.get('id')
+        data = await api.fetch_show_progress(id)
+        event_data = {
+            "id": id,
+            "season": data['next_episode']['season'],
+            "episode": data['next_episode']['number'],
+        }
+        hass.bus.async_fire(DOMAIN, event_data)
+
+    hass.services.async_register(DOMAIN, "get_next_episode", handle_get_next_episode)
 
     return True
 

--- a/custom_components/trakt_tv/services.yaml
+++ b/custom_components/trakt_tv/services.yaml
@@ -1,0 +1,41 @@
+# Example services.yaml entry
+
+# Service ID
+get_next_episode:
+  # Service name as shown in UI
+  name: Get Next Episode
+  # Description of the service
+  description: Gets the episode that you are on for the show provided.
+  # # Target entity_id (https://www.home-assistant.io/docs/blueprint/automation-trigger/#target)
+  # target:
+  #   entity:
+  #     domain: fan
+  #     # listed supported features.
+  #     supported_features:
+  #       - fan.FanEntityFeature.SET_SPEED
+  # Different fields that your service accepts
+  fields:
+    # Key of the field
+    id:
+      # Field name as shown in UI
+      name: ID
+      # Description of the field
+      description: The ID of the show.
+      # Whether or not field is required (default = false)
+      required: true
+      # Advanced fields are only shown when the advanced mode is enabled for the user
+      # (default = false)
+      advanced: false
+      # Example value that can be passed for this field
+      example: 143562
+      # # The default field value
+      # default: "high"
+      # # Selector (https://www.home-assistant.io/docs/blueprint/selectors/) to control
+      # # the input UI for this field
+      # selector:
+      #   select:
+      #     options:
+      #       - "off"
+      #       - "low"
+      #       - "medium"
+      #       - "high"

--- a/custom_components/trakt_tv/services.yaml
+++ b/custom_components/trakt_tv/services.yaml
@@ -1,41 +1,10 @@
-# Example services.yaml entry
-
-# Service ID
 get_next_episode:
-  # Service name as shown in UI
   name: Get Next Episode
-  # Description of the service
   description: Gets the episode that you are on for the show provided.
-  # # Target entity_id (https://www.home-assistant.io/docs/blueprint/automation-trigger/#target)
-  # target:
-  #   entity:
-  #     domain: fan
-  #     # listed supported features.
-  #     supported_features:
-  #       - fan.FanEntityFeature.SET_SPEED
-  # Different fields that your service accepts
   fields:
-    # Key of the field
     id:
-      # Field name as shown in UI
       name: ID
-      # Description of the field
       description: The ID of the show.
-      # Whether or not field is required (default = false)
       required: true
-      # Advanced fields are only shown when the advanced mode is enabled for the user
-      # (default = false)
       advanced: false
-      # Example value that can be passed for this field
       example: 143562
-      # # The default field value
-      # default: "high"
-      # # Selector (https://www.home-assistant.io/docs/blueprint/selectors/) to control
-      # # the input UI for this field
-      # selector:
-      #   select:
-      #     options:
-      #       - "off"
-      #       - "low"
-      #       - "medium"
-      #       - "high"


### PR DESCRIPTION
Adds the call_service "trakt.get_next_episode" which fires event type "trakt_tv" containing the id, season and episode